### PR TITLE
feat: add Commandante espresso recipes and fix Chemex grind settings

### DIFF
--- a/bulletproof-dialing-framework.md
+++ b/bulletproof-dialing-framework.md
@@ -196,10 +196,12 @@
 
 | Model         | Clicks       |
 | ------------- | ------------ |
-| Standard Axle | 40-45 clicks |
-| Red Clix      | 55-65 clicks |
+| Standard Axle | 25-34 clicks |
+| Red Clix      | 50-68 clicks |
 
-> 📄 **STATED**: "Chemex: Standard-axle model: 40-45 clicks, Red Clix model: 55-65 clicks" [Source: Coffeedesk]
+> 📄 **STATED**: "Pour over: 16-34 clicks (Standard-axle), 31-68 clicks (Red Clix)" [Source: Honest Coffee Guide]
+
+> 📄 **STATED**: "Chemex: 26-30 clicks" [Source: Tasting Grounds]
 
 **Note:** Chemex requires COARSER than V60 due to thicker filters
 
@@ -222,8 +224,8 @@
 
 | Parameter        | Light Roast    | Medium Roast | Dark Roast   |
 | ---------------- | -------------- | ------------ | ------------ |
-| Grind (Standard) | 38-42 clicks   | 42-45 clicks | 45-48 clicks |
-| Grind (Red Clix) | 52-58 clicks   | 58-65 clicks | 65-72 clicks |
+| Grind (Standard) | 25-28 clicks   | 28-31 clicks | 31-34 clicks |
+| Grind (Red Clix) | 50-56 clicks   | 56-62 clicks | 62-68 clicks |
 | Temperature      | 96°C (boiling) | 93°C         | 90°C         |
 | Ratio            | 1:16 - 1:17    | 1:15 - 1:16  | 1:14 - 1:15  |
 | Brew Time        | 4:00 - 4:45    | 3:30 - 4:15  | 3:15 - 4:00  |
@@ -386,7 +388,7 @@
 | Method    | Light Roast  | Medium       | Dark Roast   |
 | --------- | ------------ | ------------ | ------------ |
 | V60       | 22-25 clicks | 25-28 clicks | 28-32 clicks |
-| Chemex    | 38-42 clicks | 42-45 clicks | 45-48 clicks |
+| Chemex    | 25-28 clicks | 28-31 clicks | 31-34 clicks |
 | Aeropress | 18-21 clicks | 21-24 clicks | 24-28 clicks |
 
 ### Brew Time Adjustment
@@ -436,7 +438,7 @@ IF switching to DARKER roast:
 | 20-22  | Standard Aeropress       |
 | 23-28  | V60 (single cup)         |
 | 28-32  | V60 (larger brew)        |
-| 40-45  | Chemex                   |
+| 25-34  | Chemex                   |
 
 ---
 
@@ -471,9 +473,9 @@ ITERATE → Adjust based on results
 | #   | Source               | URL                                                                                                                                | Type     |
 | --- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | 1   | Espresso Aficionados | [espressoaf.com](https://espressoaf.com/guides/beginner.html)                                                                      | Guide    |
-| 2   | Honest Coffee Guide  | [honestcoffeeguide.com](https://honestcoffeeguide.com/timemore-sculptor-078s-grind-settings/)                                      | Settings |
+| 2   | Honest Coffee Guide  | [honestcoffeeguide.com](https://honestcoffeeguide.com/comandante-c40-mk4-grind-settings/)                                          | Settings |
 | 3   | Basic Barista        | [thebasicbarista.com](https://thebasicbarista.com/en-us/blogs/article/comandante-grind-size-chart)                                 | Chart    |
-| 4   | Coffeedesk           | [coffeedesk.com](https://www.coffeedesk.com/blog/how-to-set-the-comandante-grinder/)                                               | Guide    |
+| 4   | Tasting Grounds      | [tastinggrounds.com](https://tastinggrounds.com/learn/grind-sizes)                                                                 | Chart    |
 | 5   | Counter Culture      | [counterculturecoffee.com](https://counterculturecoffee.com/blogs/counter-culture-coffee/guide-to-the-aeropress)                   | Guide    |
 | 6   | Low Key Coffee Snobs | [lowkeycoffeesnobs.com](https://www.lowkeycoffeesnobs.com/hario-v60-recipe/)                                                       | Recipe   |
 | 7   | Bean Ground          | [beanground.com](https://www.beanground.com/chemex-grind-size/)                                                                    | Guide    |

--- a/src/lib/components/wizard/StepGrinder.test.ts
+++ b/src/lib/components/wizard/StepGrinder.test.ts
@@ -37,7 +37,7 @@ describe('StepGrinder', () => {
 		render(StepGrinder);
 
 		expect(screen.getByText(/Timemore/i)).toBeInTheDocument();
-		expect(screen.queryByText(/Commandante/i)).not.toBeInTheDocument();
+		expect(screen.getAllByText(/Commandante/i).length).toBeGreaterThan(0);
 	});
 
 	it('displays only compatible grinders for V60', () => {

--- a/src/lib/data/recipes.test.ts
+++ b/src/lib/data/recipes.test.ts
@@ -53,8 +53,22 @@ describe('Recipe Database', () => {
 			expect(recipe).toBeUndefined();
 		});
 
-		it('returns undefined for non-existent combination', () => {
+		it('returns espresso recipe for light roast with Commandante Standard', () => {
 			const recipe = getRecipe('espresso', 'light', 'commandante-c40-std');
+			expect(recipe).toBeDefined();
+			expect(recipe?.brewMethod).toBe('espresso');
+			expect(recipe?.roastLevel).toBe('light');
+		});
+
+		it('returns espresso recipe for medium roast with Commandante Red Clix', () => {
+			const recipe = getRecipe('espresso', 'medium', 'commandante-c40-red');
+			expect(recipe).toBeDefined();
+			expect(recipe?.brewMethod).toBe('espresso');
+			expect(recipe?.roastLevel).toBe('medium');
+		});
+
+		it('returns undefined for non-existent combination', () => {
+			const recipe = getRecipe('v60', 'light', 'timemore-078s');
 			expect(recipe).toBeUndefined();
 		});
 	});
@@ -92,6 +106,34 @@ describe('Recipe Database', () => {
 			const recipe = getRecipe('espresso', 'dark', 'timemore-078s');
 			expect(recipe?.temperature).toContain('90-92°C');
 		});
+
+		it('light roast has correct Commandante Standard range', () => {
+			const recipe = getRecipe('espresso', 'light', 'commandante-c40-std');
+			expect(recipe?.grindSetting[0].value).toBe('10-12');
+			expect(recipe?.grindSetting[0].unit).toBe('clicks');
+		});
+
+		it('medium roast has correct Commandante Red Clix range', () => {
+			const recipe = getRecipe('espresso', 'medium', 'commandante-c40-red');
+			expect(recipe?.grindSetting[0].value).toBe('20-22');
+			expect(recipe?.grindSetting[0].unit).toBe('clicks');
+		});
+
+		it('dark roast Commandante has lower temperature and ratio', () => {
+			const recipe = getRecipe('espresso', 'dark', 'commandante-c40-std');
+			expect(recipe?.temperature).toContain('88-92°C');
+			expect(recipe?.ratio).toContain('1:1.5');
+		});
+
+		it('Commandante light roast finer than dark', () => {
+			const lightRecipe = getRecipe('espresso', 'light', 'commandante-c40-std');
+			const darkRecipe = getRecipe('espresso', 'dark', 'commandante-c40-std');
+
+			const lightGrind = parseInt(lightRecipe?.grindSetting[0].value || '0');
+			const darkGrind = parseInt(darkRecipe?.grindSetting[0].value || '0');
+
+			expect(lightGrind).toBeLessThan(darkGrind);
+		});
 	});
 
 	describe('V60 recipes accuracy', () => {
@@ -112,11 +154,11 @@ describe('Recipe Database', () => {
 	});
 
 	describe('getAvailableGrinderIds', () => {
-		it('returns only Timemore 078S for espresso', () => {
+		it('returns Timemore and Commandante for espresso', () => {
 			const grinderIds = getAvailableGrinderIds('espresso', 'medium');
 			expect(grinderIds).toContain('timemore-078s');
-			expect(grinderIds).not.toContain('commandante-c40-std');
-			expect(grinderIds).not.toContain('commandante-c40-red');
+			expect(grinderIds).toContain('commandante-c40-std');
+			expect(grinderIds).toContain('commandante-c40-red');
 		});
 
 		it('returns Commandante grinders for V60', () => {

--- a/src/lib/data/recipes.ts
+++ b/src/lib/data/recipes.ts
@@ -48,6 +48,100 @@ export const recipes: BrewRecipe[] = [
 		]
 	},
 
+	// ESPRESSO - Commandante C40 Standard Axle
+	{
+		brewMethod: 'espresso',
+		roastLevel: 'light',
+		grindSetting: [{ grinderId: 'commandante-c40-std', value: '10-12', unit: 'clicks' }],
+		ratio: '1:2.5-1:3',
+		temperature: '94-96°C',
+		time: '30-40s',
+		steps: [
+			'Lock dose (18g)',
+			'Set ratio 1:2.5 (18g → 45g)',
+			'Grind 10-12 clicks',
+			'Target 30-40s extraction',
+			'Taste: if sour, increase ratio to 1:3'
+		]
+	},
+	{
+		brewMethod: 'espresso',
+		roastLevel: 'medium',
+		grindSetting: [{ grinderId: 'commandante-c40-std', value: '12-14', unit: 'clicks' }],
+		ratio: '1:2-1:2.5',
+		temperature: '92-94°C',
+		time: '25-35s',
+		steps: [
+			'Lock dose (18g)',
+			'Set ratio 1:2 (18g → 36g)',
+			'Grind 12-14 clicks',
+			'Target 25-35s extraction',
+			'Adjust ratio if sour (increase) or bitter (decrease)'
+		]
+	},
+	{
+		brewMethod: 'espresso',
+		roastLevel: 'dark',
+		grindSetting: [{ grinderId: 'commandante-c40-std', value: '14-16', unit: 'clicks' }],
+		ratio: '1:1.5-1:2',
+		temperature: '88-92°C',
+		time: '22-30s',
+		steps: [
+			'Lock dose (18g)',
+			'Set ratio 1:1.5 (18g → 27g)',
+			'Grind 14-16 clicks',
+			'Target 22-30s extraction',
+			'Lower temp prevents over-extraction'
+		]
+	},
+
+	// ESPRESSO - Commandante C40 Red Clix
+	{
+		brewMethod: 'espresso',
+		roastLevel: 'light',
+		grindSetting: [{ grinderId: 'commandante-c40-red', value: '18-20', unit: 'clicks' }],
+		ratio: '1:2.5-1:3',
+		temperature: '94-96°C',
+		time: '30-40s',
+		steps: [
+			'Lock dose (18g)',
+			'Set ratio 1:2.5 (18g → 45g)',
+			'Grind 18-20 clicks (Red Clix)',
+			'Target 30-40s extraction',
+			'Taste: if sour, increase ratio to 1:3'
+		]
+	},
+	{
+		brewMethod: 'espresso',
+		roastLevel: 'medium',
+		grindSetting: [{ grinderId: 'commandante-c40-red', value: '20-22', unit: 'clicks' }],
+		ratio: '1:2-1:2.5',
+		temperature: '92-94°C',
+		time: '25-35s',
+		steps: [
+			'Lock dose (18g)',
+			'Set ratio 1:2 (18g → 36g)',
+			'Grind 20-22 clicks (Red Clix)',
+			'Target 25-35s extraction',
+			'Adjust ratio if sour (increase) or bitter (decrease)'
+		]
+	},
+	{
+		brewMethod: 'espresso',
+		roastLevel: 'dark',
+		grindSetting: [{ grinderId: 'commandante-c40-red', value: '22-26', unit: 'clicks' }],
+		ratio: '1:1.5-1:2',
+		temperature: '88-92°C',
+		time: '22-30s',
+		steps: [
+			'Lock dose (18g)',
+			'Set ratio 1:1.5 (18g → 27g)',
+			'Grind 22-26 clicks (Red Clix)',
+			'Target 22-30s extraction',
+			'Lower temp prevents over-extraction'
+		]
+	},
+
 	// V60 - Commandante C40 Standard Axle
 	{
 		brewMethod: 'v60',
@@ -144,13 +238,13 @@ export const recipes: BrewRecipe[] = [
 	{
 		brewMethod: 'chemex',
 		roastLevel: 'light',
-		grindSetting: [{ grinderId: 'commandante-c40-std', value: '38-42', unit: 'clicks' }],
+		grindSetting: [{ grinderId: 'commandante-c40-std', value: '25-28', unit: 'clicks' }],
 		ratio: '1:16-1:17',
 		temperature: '96°C',
 		time: '4:00-4:45',
 		steps: [
 			'Set ratio 1:16 (30g → 480g)',
-			'Grind 38-42 clicks',
+			'Grind 25-28 clicks',
 			'Bloom: 90-120g water, wait 30-45s',
 			'Pulse pours of 100-120g',
 			'Total time 4:00-4:45'
@@ -159,13 +253,13 @@ export const recipes: BrewRecipe[] = [
 	{
 		brewMethod: 'chemex',
 		roastLevel: 'light',
-		grindSetting: [{ grinderId: 'commandante-c40-red', value: '52-58', unit: 'clicks' }],
+		grindSetting: [{ grinderId: 'commandante-c40-red', value: '50-56', unit: 'clicks' }],
 		ratio: '1:16-1:17',
 		temperature: '96°C',
 		time: '4:00-4:45',
 		steps: [
 			'Set ratio 1:16 (30g → 480g)',
-			'Grind 52-58 clicks (Red Clix)',
+			'Grind 50-56 clicks (Red Clix)',
 			'Bloom: 90-120g water, wait 30-45s',
 			'Pulse pours of 100-120g',
 			'Total time 4:00-4:45'
@@ -174,13 +268,13 @@ export const recipes: BrewRecipe[] = [
 	{
 		brewMethod: 'chemex',
 		roastLevel: 'medium',
-		grindSetting: [{ grinderId: 'commandante-c40-std', value: '42-45', unit: 'clicks' }],
+		grindSetting: [{ grinderId: 'commandante-c40-std', value: '28-31', unit: 'clicks' }],
 		ratio: '1:15-1:16',
 		temperature: '93°C',
 		time: '3:30-4:15',
 		steps: [
 			'Set ratio 1:16 (30g → 480g)',
-			'Grind 42-45 clicks',
+			'Grind 28-31 clicks',
 			'Bloom: 90-120g water, wait 30-45s',
 			'Pulse pours of 100-120g',
 			'Total time 3:30-4:15'
@@ -189,13 +283,13 @@ export const recipes: BrewRecipe[] = [
 	{
 		brewMethod: 'chemex',
 		roastLevel: 'medium',
-		grindSetting: [{ grinderId: 'commandante-c40-red', value: '58-65', unit: 'clicks' }],
+		grindSetting: [{ grinderId: 'commandante-c40-red', value: '56-62', unit: 'clicks' }],
 		ratio: '1:15-1:16',
 		temperature: '93°C',
 		time: '3:30-4:15',
 		steps: [
 			'Set ratio 1:16 (30g → 480g)',
-			'Grind 58-65 clicks (Red Clix)',
+			'Grind 56-62 clicks (Red Clix)',
 			'Bloom: 90-120g water, wait 30-45s',
 			'Pulse pours of 100-120g',
 			'Total time 3:30-4:15'
@@ -204,13 +298,13 @@ export const recipes: BrewRecipe[] = [
 	{
 		brewMethod: 'chemex',
 		roastLevel: 'dark',
-		grindSetting: [{ grinderId: 'commandante-c40-std', value: '45-48', unit: 'clicks' }],
+		grindSetting: [{ grinderId: 'commandante-c40-std', value: '31-34', unit: 'clicks' }],
 		ratio: '1:14-1:15',
 		temperature: '90°C',
 		time: '3:15-4:00',
 		steps: [
 			'Set ratio 1:15 (30g → 450g)',
-			'Grind 45-48 clicks',
+			'Grind 31-34 clicks',
 			'Bloom: 90g water, wait 30s',
 			'Pulse pours of 100g',
 			'Total time 3:15-4:00'
@@ -219,13 +313,13 @@ export const recipes: BrewRecipe[] = [
 	{
 		brewMethod: 'chemex',
 		roastLevel: 'dark',
-		grindSetting: [{ grinderId: 'commandante-c40-red', value: '65-72', unit: 'clicks' }],
+		grindSetting: [{ grinderId: 'commandante-c40-red', value: '62-68', unit: 'clicks' }],
 		ratio: '1:14-1:15',
 		temperature: '90°C',
 		time: '3:15-4:00',
 		steps: [
 			'Set ratio 1:15 (30g → 450g)',
-			'Grind 65-72 clicks (Red Clix)',
+			'Grind 62-68 clicks (Red Clix)',
 			'Bloom: 90g water, wait 30s',
 			'Pulse pours of 100g',
 			'Total time 3:15-4:00'


### PR DESCRIPTION
## Motivation

Add missing Commandante C40 espresso support and correct Chemex grind settings based on user research. Previous Chemex settings (38-48 clicks standard) were too coarse compared to industry standards.

## Implementation information

**Added Commandante espresso recipes:**
- 6 new recipes: Light/Medium/Dark roasts × Standard/Red Clix variants
- Settings from bulletproof-dialing-framework.md:
  - Standard: 10-12 (light), 12-14 (medium), 14-16 (dark) clicks
  - Red Clix: 18-20 (light), 20-22 (medium), 22-26 (dark) clicks

**Fixed Chemex grind settings:**
- Research revealed previous settings too high (40-45 clicks)
- Updated based on Honest Coffee Guide + Tasting Grounds
- New range: 25-34 clicks (standard), 50-68 clicks (Red Clix)
- Roast-adjusted: Light 25-28, Medium 28-31, Dark 31-34 (standard)

**Updated:**
- `src/lib/data/recipes.ts`: Added 6 espresso + updated 6 Chemex recipes
- `src/lib/data/recipes.test.ts`: Added Commandante espresso tests
- `src/lib/components/wizard/StepGrinder.test.ts`: Updated expectations
- `bulletproof-dialing-framework.md`: Corrected settings + sources

All 213 tests pass.

## Supporting documentation

Research sources:
- [Honest Coffee Guide - C40 MK4](https://honestcoffeeguide.com/comandante-c40-mk4-grind-settings/)
- [Honest Coffee Guide - Red Clix](https://honestcoffeeguide.com/comandante-c40-mk4-with-red-clix-grind-settings/)
- [Tasting Grounds - Grind Sizes](https://tastinggrounds.com/learn/grind-sizes)