### PR TITLE
feat: add single-action Cloudflare Pages deployment workflow

### DIFF
--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -99,7 +99,7 @@ git push origin production
 
 ### Cloudflare Pages Project
 
-**Project name:** `home-barista-helper` (change in `deploy-production.yml:43`)
+**Project name:** `home-barista-helper` (change in `production-deploy.yml:61`)
 
 **Build settings:**
 
@@ -127,6 +127,6 @@ git push origin production
 **Check deployment:**
 
 ```bash
-gh run list --workflow=deploy-production.yml
+gh run list --workflow=production-deploy.yml
 gh run view <run-id>
 ```

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           if [ "${{ steps.check_branch.outputs.exists }}" == "false" ]; then
             echo "Creating production branch from main"
+            git checkout main
             git checkout -b production
             git push -u origin production
             echo "action=created" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Motivation

Setup Cloudflare Pages deployment from production branch with single GitHub Actions workflow trigger.

## Implementation information

Single workflow (`production-deploy.yml`) triggered manually that:
1. Creates/updates production branch from main (with fast-forward or merge commit)
2. Builds SvelteKit app with paraglide i18n
3. Deploys to Cloudflare Pages
4. Checks deployment status
5. Comments deployment URL on production branch commit

Replaces split workflow approach with consolidated single-trigger action.

## Supporting documentation

- `.github/DEPLOYMENT.md` - Setup guide with required secrets and usage
- Required secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`
- Workflow name: "Production Deploy"

## Test plan
- [ ] Configure Cloudflare secrets in repo settings
- [ ] Verify project name matches Cloudflare Pages project
- [ ] Run workflow via Actions UI or `gh workflow run production-deploy.yml`
- [ ] Verify production branch created/updated
- [ ] Verify build succeeds
- [ ] Verify deployment to Cloudflare Pages
- [ ] Check deployment URL in commit comment