### PR TITLE
fix: update cf-pages-await action to v1.3.1

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Wait for Cloudflare Pages deployment
         id: cloudflare
-        uses: WalshyDev/cf-pages-await@66a2d4724571b44a8c6b52049dea8f2c388f7f3f # v1.2.2
+        uses: WalshyDev/cf-pages-await@3abae9f62a7672a1701300702ce42908e16cb88a # v1.3.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Motivation

Production Deploy workflow failing - `cf-pages-await` action commit SHA no longer accessible.

## Implementation information

Updated `WalshyDev/cf-pages-await` from invalid SHA to v1.3.1 (`3abae9f62a7672a1701300702ce42908e16cb88a`).

## Supporting documentation

Fixes: https://github.com/Automaat/home-barista-helper/actions/runs/20481501644