### PR TITLE
fix: grant deployments:write permission to production workflow

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      deployments: read
+      deployments: write
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
## Motivation

Production deployment workflow fails with 403 error: "Resource not accessible by integration" when cf-pages-await action attempts to create GitHub deployments.

## Implementation information

Changed `deployments: read` to `deployments: write` in workflow permissions. The cf-pages-await action requires write access to create deployment status updates on GitHub.

## Supporting documentation

Failed workflow run: https://github.com/Automaat/home-barista-helper/actions/runs/20481949362/job/58856890434